### PR TITLE
[CLUST-22] Add setting API document

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@ all: format compile
 
 format:
 	@echo -e ":: $(GREEN)Checking TypeSpec format...$(NC)"
-	@tsp format "**/*.tsp" \
+	@npx tsp format "**/*.tsp" \
 		&& echo -e "==> $(BLUE)Format check completed$(NC)" \
 		|| (echo -e "==> $(RED)Format check failed$(NC)" && exit 1)
 
 compile:
 	@echo -e ":: $(GREEN)Compiling TypeSpec...$(NC)"
-	@tsp compile . \
+	@npx tsp compile . \
 		&& echo -e "==> $(BLUE)Compilation completed$(NC)" \
 		|| (echo -e "==> $(RED)Compilation failed$(NC)" && exit 1)
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ format:
 
 compile:
 	@echo -e ":: $(GREEN)Compiling TypeSpec...$(NC)"
-	@npx tsp compile . \
+	@npx -p @typespec/compiler tsp compile . \
 		&& echo -e "==> $(BLUE)Compilation completed$(NC)" \
 		|| (echo -e "==> $(RED)Compilation failed$(NC)" && exit 1)
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all: format compile
 
 format:
 	@echo -e ":: $(GREEN)Checking TypeSpec format...$(NC)"
-	@npx tsp format "**/*.tsp" \
+	@npx -p @typespec/compiler tsp format "**/*.tsp" \
 		&& echo -e "==> $(BLUE)Format check completed$(NC)" \
 		|| (echo -e "==> $(RED)Format check failed$(NC)" && exit 1)
 

--- a/main.tsp
+++ b/main.tsp
@@ -15,7 +15,9 @@ enum Versions {
 
 @doc("User settings that are needed for access to the machine.")
 model UserSettings {
+  @doc("The computer username of the user.")
   username: string;
+
   publicKey: string[];
 }
 

--- a/main.tsp
+++ b/main.tsp
@@ -4,7 +4,7 @@ import "@typespec/versioning";
 using Http;
 using Versioning;
 
-@service(#{ title: "Clustron api", version: "1.0.0" })
+@service(#{ title: "Clustron API", version: "1.0.0" })
 @server("https://example.com", "Single server endpoint")
 @versioned(Versions)
 namespace Clustron;
@@ -13,62 +13,47 @@ enum Versions {
   v1: "1.0.0",
 }
 
-@doc("Represent a Pet available in the PetStore")
-model Pet {
-  id: int32;
-
-  @minLength(1)
-  name: string;
-
-  @minValue(0)
-  @maxValue(100)
-  age: int32;
-
-  kind: petType;
+@doc("User settings that are needed for access to the machine.")
+model UserSettings {
+  username: string;
+  publicKey: string[];
 }
 
-enum petType {
-  dog: "dog",
-  cat: "cat",
-  fish: "fish",
-  bird: "bird",
-  reptile: "reptile",
-}
-
-@route("/pets")
-namespace Pets {
+@tag("User")
+namespace Settings {
+  @route("/settings")
   @get
-  op listPets(@offset skip?: int32 = 0): {
-    @pageItems pets: Pet[];
-  };
-
-  @get
-  op getPet(@path petId: int32): {
+  op getUserSettings(): {
     @statusCode statusCode: 200;
-    @body pet: Pet;
+    @body settings: UserSettings;
   } | {
     @statusCode statusCode: 404;
   };
 
-  @post
-  op createPet(@body pet: Pet): {
-    @statusCode statusCode: 201;
-    @body newPet: Pet;
-  } | {
-    @statusCode statusCode: 202;
-    @body acceptedPet: Pet;
-  };
-
+  @route("/settings/username")
   @put
-  op updatePet(@path petId: int32, @body pet: Pet): {
+  op updateUsername(@body username: string): {
     @statusCode statusCode: 200;
-    @body updatedPet: Pet;
+    @body username: string;
   } | {
     @statusCode statusCode: 404;
   };
 
+  @route("/settings/publickey")
+  @post
+  op addPublicKey(@body publicKey: string): {
+    @statusCode statusCode: 200;
+    @body publicKey: string;
+  } | {
+    @statusCode statusCode: 404;
+  };
+
+  @route("/settings/publickey")
   @delete
-  op deletePet(@path petId: int32): {
-    @statusCode statusCode: 204;
+  op deletePublicKey(@body publicKey: string): {
+    @statusCode statusCode: 200;
+    @body publicKey: string;
+  } | {
+    @statusCode statusCode: 404;
   };
 }

--- a/main.tsp
+++ b/main.tsp
@@ -31,10 +31,28 @@ namespace Settings {
   };
 
   @route("/settings/username")
+  @get
+  op getUsername(): {
+    @statusCode statusCode: 200;
+    @body username: string;
+  } | {
+    @statusCode statusCode: 404;
+  };
+
+  @route("/settings/username")
   @put
   op updateUsername(@body username: string): {
     @statusCode statusCode: 200;
     @body username: string;
+  } | {
+    @statusCode statusCode: 404;
+  };
+
+  @route("/settings/publickey")
+  @get
+  op getPublicKey(): {
+    @statusCode statusCode: 200;
+    @body publicKey: string[];
   } | {
     @statusCode statusCode: 404;
   };

--- a/main.tsp
+++ b/main.tsp
@@ -4,10 +4,10 @@ import "@typespec/versioning";
 using Http;
 using Versioning;
 
-@service(#{ title: "Pet Store", version: "1.0.0" })
+@service(#{ title: "Clustron api", version: "1.0.0" })
 @server("https://example.com", "Single server endpoint")
 @versioned(Versions)
-namespace PetStore;
+namespace Clustron;
 
 enum Versions {
   v1: "1.0.0",

--- a/main.tsp
+++ b/main.tsp
@@ -16,8 +16,14 @@ enum Versions {
 model UserSettings {
   @doc("The computer username of the user.")
   username: string;
+}
 
-  publicKey: string[];
+model PublicKey {
+  @doc("The public key title set by the user.")
+  title: string;
+
+  @doc("The public key of the user.")
+  publicKey: string;
 }
 
 @tag("User")
@@ -31,6 +37,15 @@ namespace Settings {
     @statusCode statusCode: 404;
   };
 
+  @route("/settings")
+  @put
+  op updateUsername(@body username: string): {
+    @statusCode statusCode: 200;
+    @body username: string;
+  } | {
+    @statusCode statusCode: 404;
+  };
+
   @route("/settings/username")
   @get
   op getUsername(): {
@@ -40,38 +55,33 @@ namespace Settings {
     @statusCode statusCode: 404;
   };
 
-  @route("/settings/username")
-  @put
-  op updateUsername(@body username: string): {
-    @statusCode statusCode: 200;
-    @body username: string;
-  } | {
-    @statusCode statusCode: 404;
-  };
-
-  @route("/settings/publickey")
+  @route("/publickey")
   @get
-  op getPublicKey(): {
+  op getPublicKey(
+    @doc("Get 10 head characters of publickey as short public key in 'publickey' field.")
+    @query
+    short?: boolean,
+  ): {
     @statusCode statusCode: 200;
-    @body publicKey: string[];
+    @body publicKey: PublicKey[];
   } | {
     @statusCode statusCode: 404;
   };
 
-  @route("/settings/publickey")
+  @route("/publickey")
   @post
   op addPublicKey(@body publicKey: string): {
     @statusCode statusCode: 200;
-    @body publicKey: string;
+    @body publicKey: PublicKey;
   } | {
     @statusCode statusCode: 404;
   };
 
-  @route("/settings/publickey")
+  @route("/publickey")
   @delete
   op deletePublicKey(@body publicKey: string): {
     @statusCode statusCode: 200;
-    @body publicKey: string;
+    @body title: string;
   } | {
     @statusCode statusCode: 404;
   };

--- a/main.tsp
+++ b/main.tsp
@@ -13,7 +13,6 @@ enum Versions {
   v1: "1.0.0",
 }
 
-@doc("User settings that are needed for access to the machine.")
 model UserSettings {
   @doc("The computer username of the user.")
   username: string;


### PR DESCRIPTION
Type of change
- Feature

Purpose
- Add API document for user setting endpoint.
- Allow both the frontend and backend teams to implement the same spec to increase the efficiency of integration.