### PR TITLE
Add "api" as prefix of every route

### DIFF
--- a/main.tsp
+++ b/main.tsp
@@ -7,6 +7,7 @@ using Versioning;
 @service(#{ title: "Clustron API", version: "1.0.0" })
 @server("https://example.com", "Single server endpoint")
 @versioned(Versions)
+@route("/api")
 namespace Clustron;
 
 enum Versions {


### PR DESCRIPTION
# Type of change
- Fix

# Purpose
- Add an "api" prefix on every route to distinguish the frontend and API URL.