### PR TITLE
Add name field to settings and update request and response body model

### DIFF
--- a/main.tsp
+++ b/main.tsp
@@ -15,11 +15,17 @@ enum Versions {
 }
 
 model UserSettings {
-  @doc("The computer username of the user.")
+  @doc("The realname of the user.")
   username: string;
+
+  @doc("The computer hostname of the user.")
+  linuxUsername: string;
 }
 
 model PublicKey {
+  @doc("The public key id in UUID format.")
+  id: string;
+
   @doc("The public key title set by the user.")
   title: string;
 
@@ -29,6 +35,19 @@ model PublicKey {
 
 @tag("User")
 namespace Settings {
+  model AddPublicKeyRequest {
+    @doc("The public key title set by the user.")
+    title: string;
+
+    @doc("The public key of the user.")
+    publicKey: string;
+  }
+
+  model DeletePublicKeyRequest {
+    @doc("The public key id in UUID format.")
+    id: string;
+  }
+
   @route("/settings")
   @get
   op getUserSettings(): {
@@ -40,18 +59,9 @@ namespace Settings {
 
   @route("/settings")
   @put
-  op updateUsername(@body username: string): {
+  op updateSettings(@body body: UserSettings): {
     @statusCode statusCode: 200;
-    @body username: string;
-  } | {
-    @statusCode statusCode: 404;
-  };
-
-  @route("/settings/username")
-  @get
-  op getUsername(): {
-    @statusCode statusCode: 200;
-    @body username: string;
+    @body newSettings: UserSettings;
   } | {
     @statusCode statusCode: 404;
   };
@@ -71,7 +81,7 @@ namespace Settings {
 
   @route("/publickey")
   @post
-  op addPublicKey(@body publicKey: string): {
+  op addPublicKey(@body body: AddPublicKeyRequest): {
     @statusCode statusCode: 200;
     @body publicKey: PublicKey;
   } | {
@@ -80,9 +90,8 @@ namespace Settings {
 
   @route("/publickey")
   @delete
-  op deletePublicKey(@body publicKey: string): {
+  op deletePublicKey(@body body: DeletePublicKeyRequest): {
     @statusCode statusCode: 200;
-    @body title: string;
   } | {
     @statusCode statusCode: 404;
   };

--- a/main.tsp
+++ b/main.tsp
@@ -18,7 +18,7 @@ model UserSettings {
   @doc("The real name of the user.")
   username: string;
 
-  @doc("The computer hostname of the user.")
+  @doc("The computer account name of the user.")
   linuxUsername: string;
 }
 

--- a/main.tsp
+++ b/main.tsp
@@ -15,7 +15,7 @@ enum Versions {
 }
 
 model UserSettings {
-  @doc("The realname of the user.")
+  @doc("The real name of the user.")
   username: string;
 
   @doc("The computer hostname of the user.")


### PR DESCRIPTION
# Type of change
- Fix

# Purpose
- Add a name field to record the real name of the user because the NYCU portal doesn't provide the username.
- Update the request and response body model to reflect the change
- Define the request body of public key CRUD to clarify the data field format.