### PR TITLE
Add OAuth2 login and token refresh routes

### DIFF
--- a/main.tsp
+++ b/main.tsp
@@ -1,5 +1,7 @@
 import "@typespec/http";
 import "@typespec/versioning";
+import "./service/user.tsp";
+import "./service/auth.tsp";
 
 using Http;
 using Versioning;
@@ -12,87 +14,4 @@ namespace Clustron;
 
 enum Versions {
   v1: "1.0.0",
-}
-
-model UserSettings {
-  @doc("The real name of the user.")
-  username: string;
-
-  @doc("The computer account name of the user.")
-  linuxUsername: string;
-}
-
-model PublicKey {
-  @doc("The public key id in UUID format.")
-  id: string;
-
-  @doc("The public key title set by the user.")
-  title: string;
-
-  @doc("The public key of the user.")
-  publicKey: string;
-}
-
-@tag("User")
-namespace Settings {
-  model AddPublicKeyRequest {
-    @doc("The public key title set by the user.")
-    title: string;
-
-    @doc("The public key of the user.")
-    publicKey: string;
-  }
-
-  model DeletePublicKeyRequest {
-    @doc("The public key id in UUID format.")
-    id: string;
-  }
-
-  @route("/settings")
-  @get
-  op getUserSettings(): {
-    @statusCode statusCode: 200;
-    @body settings: UserSettings;
-  } | {
-    @statusCode statusCode: 404;
-  };
-
-  @route("/settings")
-  @put
-  op updateSettings(@body body: UserSettings): {
-    @statusCode statusCode: 200;
-    @body newSettings: UserSettings;
-  } | {
-    @statusCode statusCode: 404;
-  };
-
-  @route("/publickey")
-  @get
-  op getPublicKey(
-    @doc("Get 10 head characters of publickey as short public key in 'publickey' field.")
-    @query
-    short?: boolean,
-  ): {
-    @statusCode statusCode: 200;
-    @body publicKey: PublicKey[];
-  } | {
-    @statusCode statusCode: 404;
-  };
-
-  @route("/publickey")
-  @post
-  op addPublicKey(@body body: AddPublicKeyRequest): {
-    @statusCode statusCode: 200;
-    @body publicKey: PublicKey;
-  } | {
-    @statusCode statusCode: 404;
-  };
-
-  @route("/publickey")
-  @delete
-  op deletePublicKey(@body body: DeletePublicKeyRequest): {
-    @statusCode statusCode: 200;
-  } | {
-    @statusCode statusCode: 404;
-  };
 }

--- a/service/auth.tsp
+++ b/service/auth.tsp
@@ -1,0 +1,42 @@
+import "@typespec/http";
+
+using Http;
+
+@tag("Auth")
+namespace Clustron.Auth {
+  model RefreshToken {
+    @doc("The new JWT")
+    accessToken: string;
+
+    @doc("The expiration date of the refresh token.")
+    expirationTime: integer;
+
+    @doc("The new refresh token.")
+    refreshToken: string;
+  }
+
+  @route("/login/oauth2/google")
+  @get
+  op loginGoogle(
+    @doc("The callback URL of the OAuth2 login. [See details](https://clustron.atlassian.net/wiki/spaces/cd/pages/18219016/Backend+OAuth+JWT+Manual)")
+    @query
+    c: string,
+  ): {
+    @statusCode statusCode: 302;
+  } | {
+    @statusCode statusCode: 404;
+  };
+
+  @route("/refresh/{refresh_token}")
+  @get
+  op refreshToken(
+    @doc("The refresh token to use for refreshing the access token.")
+    @path
+    refresh_token: string,
+  ): {
+    @statusCode statusCode: 200;
+    @body refreshToken: RefreshToken;
+  } | {
+    @statusCode statusCode: 404;
+  };
+}

--- a/service/user.tsp
+++ b/service/user.tsp
@@ -1,0 +1,86 @@
+import "@typespec/http";
+
+using Http;
+
+@tag("User")
+namespace Clustron.Settings {
+  model UserSettings {
+    @doc("The real name of the user.")
+    username: string;
+
+    @doc("The computer account name of the user.")
+    linuxUsername: string;
+  }
+
+  model PublicKey {
+    @doc("The public key id in UUID format.")
+    id: string;
+
+    @doc("The public key title set by the user.")
+    title: string;
+
+    @doc("The public key of the user.")
+    publicKey: string;
+  }
+
+  model AddPublicKeyRequest {
+    @doc("The public key title set by the user.")
+    title: string;
+
+    @doc("The public key of the user.")
+    publicKey: string;
+  }
+
+  model DeletePublicKeyRequest {
+    @doc("The public key id in UUID format.")
+    id: string;
+  }
+
+  @route("/settings")
+  @get
+  op getUserSettings(): {
+    @statusCode statusCode: 200;
+    @body settings: UserSettings;
+  } | {
+    @statusCode statusCode: 404;
+  };
+
+  @route("/settings")
+  @put
+  op updateSettings(@body body: UserSettings): {
+    @statusCode statusCode: 200;
+    @body newSettings: UserSettings;
+  } | {
+    @statusCode statusCode: 404;
+  };
+
+  @route("/publickey")
+  @get
+  op getPublicKey(
+    @doc("Get 10 head characters of publickey as short public key in 'publickey' field.")
+    @query
+    short?: boolean,
+  ): {
+    @statusCode statusCode: 200;
+    @body publicKey: PublicKey[];
+  } | {
+    @statusCode statusCode: 404;
+  };
+
+  @route("/publickey")
+  @post
+  op addPublicKey(@body body: AddPublicKeyRequest): {
+    @statusCode statusCode: 200;
+    @body publicKey: PublicKey;
+  } | {
+    @statusCode statusCode: 404;
+  };
+
+  @route("/publickey")
+  @delete
+  op deletePublicKey(@body body: DeletePublicKeyRequest): {
+    @statusCode statusCode: 200;
+  } | {
+    @statusCode statusCode: 404;
+  };
+}


### PR DESCRIPTION
## Type of change
- Feature

## Purpose
- Add `/api/login/oauth2/google` to let user login via google OAuth2 and redirect to a specific url with JWT and refresh token
- Add `/api/refreshToken/{refreshToken}` to get new JWT

## Additional Information
- the workflow with OAuth and JWT, [See detail](https://clustron.atlassian.net/wiki/spaces/cd/pages/18219016/Backend+OAuth+JWT+Manual)