### PR TITLE
[CLUST-44] Add logout API spec

### DIFF
--- a/service/auth.tsp
+++ b/service/auth.tsp
@@ -15,6 +15,11 @@ namespace Clustron.Auth {
     refreshToken: string;
   }
 
+  model LogoutRequest {
+    @doc("The refresh token to use for logging out.")
+    refreshToken: string;
+  }
+
   @route("/login/oauth2/google")
   @get
   op loginGoogle(
@@ -40,6 +45,17 @@ namespace Clustron.Auth {
   ): {
     @statusCode statusCode: 200;
     @body refreshToken: RefreshToken;
+  } | {
+    @statusCode statusCode: 404;
+  };
+
+  @route("/logout")
+  @post
+  op logout(
+    @body
+    refreshToken: LogoutRequest,
+  ): {
+    @statusCode statusCode: 200;
   } | {
     @statusCode statusCode: 404;
   };


### PR DESCRIPTION
# Type of change
- Feature

# Purpose
- Add logout API spec to help both frontend and backend to properly implement the logout function.
- Send the tokens back to the backend when logout to handle the black list in order to enhance the security.