### PR TITLE
Add property "me" in group response schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,10 @@ clean:
 	@echo -e ":: $(GREEN)Cleaning build artifacts...$(NC)"
 	@rm -rf tsp-output \
 		&& echo -e "==> $(BLUE)Cleanup completed$(NC)" \
-		|| (echo -e "==> $(RED)Cleanup failed$(NC)" && exit 1) 
+		|| (echo -e "==> $(RED)Cleanup failed$(NC)" && exit 1)
+
+mock:
+	@docker run --init --rm \
+	    -v $(PWD):/api \
+        -p 4010:4010 stoplight/prism:4 \
+        mock -h 0.0.0.0 "/api/tsp-output/schema/openapi.1.0.0.yaml"

--- a/service/group.tsp
+++ b/service/group.tsp
@@ -43,6 +43,9 @@ namespace Clustron.Groups {
     isArchived: boolean;
     createdAt: string;
     updatedAt: string;
+    me: {
+      role: Role;
+    };
   }
 
   model CreateGroupRequest {


### PR DESCRIPTION
# Type of change
- Feature

# Purpose
- Add "me" in the group response to record the information on the access level of the user in that group.
- Allow frontend to decide what to display base on the access level upon received data.
- Add "mock" script in Makefile to start a mock server