### PR TITLE
Add relation type in group response

### DIFF
--- a/service/group.tsp
+++ b/service/group.tsp
@@ -28,12 +28,12 @@ namespace Clustron.Groups {
     member: email | string;
 
     @doc("The access level of the user.")
-    role: string;
+    role: uuid;
   }
 
   model UpdateMemberRequest {
     id: uuid;
-    role: string;
+    role: uuid;
   }
 
   model GroupResponse {

--- a/service/group.tsp
+++ b/service/group.tsp
@@ -44,9 +44,12 @@ namespace Clustron.Groups {
     createdAt: string;
     updatedAt: string;
     me: {
+      @doc("The user is a member of the group.")
       type: "membership";
+
       role: Role;
     } | {
+      @doc("The admin user is not a member of the group.")
       type: "adminOverride";
     };
   }

--- a/service/group.tsp
+++ b/service/group.tsp
@@ -4,7 +4,7 @@ using Http;
 @tag("Group")
 namespace Clustron.Groups {
   enum AccessLevel {
-    Organizer: "organizer",
+    Organizer: "groupOwner",
     GroupAdmin: "groupAdmin",
     User: "user",
   }
@@ -44,7 +44,10 @@ namespace Clustron.Groups {
     createdAt: string;
     updatedAt: string;
     me: {
+      type: "membership";
       role: Role;
+    } | {
+      type: "adminOverride";
     };
   }
 


### PR DESCRIPTION
# Type of change
- Feature
- Fix

# Purpose
- Add `type` field in the group response. If the user is actually a member of that group, the type will be `membership`. If the user is not a member of a group but can still see it through the admin role, the type will be `adminOverride` and have no `role` field in the response.
- Change the 'role' field data type of add and update member request from `string` to UUID.


Examples:
**If the user is actually a member of that group**
```
me: {
     type: "membership",
     role: {
          id: "uuid",
          role: "student",
          accessLevel: "user"
     }
}
```

**If the user is not a member of a group but can still see it through the admin role**
```
me: {
     type: "adminOverride"
}
```