### PR TITLE
[BREAKING CHANGE] Rename 'username' to 'fullName' in UserSettings and MemberResponse

### DIFF
--- a/service/group.tsp
+++ b/service/group.tsp
@@ -17,7 +17,7 @@ namespace Clustron.Groups {
 
   model MemberResponse {
     id: uuid;
-    username: string;
+    fullName: string;
     email: email;
     studentId: string;
     role: Role;

--- a/service/user.tsp
+++ b/service/user.tsp
@@ -6,7 +6,7 @@ using Http;
 namespace Clustron.Settings {
   model UserSettings {
     @doc("The real name of the user.")
-    username: string;
+    fullName: string;
 
     @doc("The computer account name of the user.")
     linuxUsername: string;


### PR DESCRIPTION
## Type of changes
- BREAKING CHANGE
- Refactor

## Purpose
Rename username to fullName in the UserSettings and MemberResponse models.
Align field semantics with its actual usage: full_name is the real-world display name (e.g. from school OAuth), not a unique login identifier

## Additional Information
This PR introduces a breaking change by renaming the username field in the settings table to full_name. This reflects the actual semantics of the field: it's not a system-unique identifier, but rather the user's full display name returned from an OAuth provider.
Related PR: [Backend Implementation](https://github.com/NYCU-SDC/clustron-backend/pull/25)

**Affected areas include:**
- Clustron.Settings.UserSettings
```
  model UserSettings {
    @doc("The real name of the user.")
    fullName: string;

    @doc("The computer account name of the user.")
    linuxUsername: string;
  }
  ```
- Clustron.Group.MemberResponse
```
  model MemberResponse {
    id: uuid;
    fullName: string;
    email: email;
    studentId: string;
    role: Role;
  }
  ```