### PR TITLE
FIx group access level enum value to match the implementation

### DIFF
--- a/service/group.tsp
+++ b/service/group.tsp
@@ -4,9 +4,9 @@ using Http;
 @tag("Group")
 namespace Clustron.Groups {
   enum AccessLevel {
-    Organizer: "groupOwner",
-    GroupAdmin: "groupAdmin",
-    User: "user",
+    GroupOwner: "GROUP_OWNER",
+    GroupAdmin: "GROUp_ADMIN",
+    User: "USER",
   }
 
   model Role {


### PR DESCRIPTION
## Type of change
- FIx
- Refactor

## Purpose
- Change "organizer" to "groupOwner" in `Custron.Groups.AccessLevel` to fit the backend implementation.
- Refactor the string value in `Custron.Groups.AccessLevel` to Uppercase to fit the enum conventions.

## Additional informations
- Affected endpoints:
     - `GET /api/groups`
     - `POST /api/groups`
     - `GET /api/group/{id}`
     - `GET /api/group/{id}/members`
     - `POST /api/group/{id}/members`
     - `PUT /api/group/{id}/members`