### PR TITLE
[BREAKING CHANGE] Rename 'role' to 'roleName' in Role model

### DIFF
--- a/service/group.tsp
+++ b/service/group.tsp
@@ -11,7 +11,7 @@ namespace Clustron.Groups {
 
   model Role {
     id: uuid;
-    role: string;
+    roleName: string;
     accessLevel: AccessLevel;
   }
 


### PR DESCRIPTION
## Type of change
- BREAKING CHANGE
- Refactor

## Purpose
- This makes it less ambiguous that roleName is a description of a role to let people understand instead of an identification of role entry.

## Additional information
**Affected areas include**
```tsp
  model Role {
    id: uuid;
    roleName: string;
    accessLevel: AccessLevel;
  }
```