### PR TITLE
feat: add linux username field in onboarding api

### DIFF
--- a/service/user.tsp
+++ b/service/user.tsp
@@ -39,6 +39,9 @@ namespace Clustron.User {
   model OnboardingRequest {
     @doc("The real name of the user.")
     username: string;
+
+    @doc("The computer account name of the user.")
+    linuxUsername: string;
   }
 
   @route("/settings")


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add a Linux username field in the onboarding endpoint to let users input the basic information for us to create user entries for them.

## Additional information
- Current onboarding endpoint request body is as follow
```json=
{
    username: string,
    linuxUsername: string
}
```