### PR TITLE
[CLUST-110] Add external link resources to a group

### DIFF
--- a/service/group.tsp
+++ b/service/group.tsp
@@ -256,4 +256,37 @@ namespace Clustron.Groups {
   } | {
     @statusCode statusCode: 404;
   };
+
+  @doc("Create a link for a group. Will reject the request from access level 'user'.")
+  @route("/groups/{id}/link")
+  @post
+  op createGroupLink(id: string, @body body: CreateLinkRequest): {
+    @statusCode statusCode: 200;
+    @body link: LinkResponse;
+  } | {
+    @statusCode statusCode: 400;
+  };
+
+  @doc("Update a link for a group. Will reject the request from access level 'user'.")
+  @route("/groups/{id}/link/{linkId}")
+  @put
+  op updateGroupLink(
+    id: string,
+    linkId: string,
+    @body body: UpdateLinkRequest,
+  ): {
+    @statusCode statusCode: 200;
+    @body link: LinkResponse;
+  } | {
+    @statusCode statusCode: 404;
+  };
+
+  @doc("Delete a link for a group. Will reject the request from access level 'user'.")
+  @route("/groups/{id}/link/{linkId}")
+  @delete
+  op deleteGroupLink(id: string, linkId: string): {
+    @statusCode statusCode: 200;
+  } | {
+    @statusCode statusCode: 404;
+  };
 }

--- a/service/group.tsp
+++ b/service/group.tsp
@@ -77,7 +77,6 @@ namespace Clustron.Groups {
     id: uuid;
     title: string;
     description: string;
-    links: LinkResponse[];
     isArchived: boolean;
     createdAt: string;
     updatedAt: string;
@@ -90,6 +89,10 @@ namespace Clustron.Groups {
       @doc("The admin user is not a member of the group.")
       type: "adminOverride";
     };
+  }
+
+  model GroupResponseWithLinks extends GroupResponse {
+    links: LinkResponse[];
   }
 
   model AddMemberError {
@@ -135,7 +138,7 @@ namespace Clustron.Groups {
   @get
   op getGroupById(id: string): {
     @statusCode statusCode: 200;
-    @body group: GroupResponse;
+    @body group: GroupResponseWithLinks;
   } | {
     @statusCode statusCode: 404;
   };

--- a/service/group.tsp
+++ b/service/group.tsp
@@ -46,10 +46,38 @@ namespace Clustron.Groups {
     roleId: uuid;
   }
 
+  model LinkResponse {
+    @doc("The ID of the link.")
+    id: uuid;
+
+    @doc("The title of the link.")
+    title: string;
+
+    @doc("The URL of the link.")
+    url: string;
+  }
+
+  model CreateLinkRequest {
+    @doc("The title of the link.")
+    title: string;
+
+    @doc("The URL of the link.")
+    url: string;
+  }
+
+  model UpdateLinkRequest {
+    @doc("The title of the link.")
+    title: string;
+
+    @doc("The URL of the link.")
+    url: string;
+  }
+
   model GroupResponse {
     id: uuid;
     title: string;
     description: string;
+    links: LinkResponse[];
     isArchived: boolean;
     createdAt: string;
     updatedAt: string;
@@ -83,7 +111,8 @@ namespace Clustron.Groups {
   model CreateGroupRequest {
     title: string;
     description: string;
-    members: AddMemberRequest[];
+    members?: AddMemberRequest[];
+    links?: CreateLinkRequest[];
   }
 
   model TransferGroupOwnershipRequest {
@@ -181,7 +210,7 @@ namespace Clustron.Groups {
   } | {
     @statusCode statusCode: 404;
   };
-  
+
   @doc("Transfer group ownership to another member. Will reject the request from access level 'user'")
   @route("/groups/{id}/transfer")
   @post
@@ -194,7 +223,7 @@ namespace Clustron.Groups {
   } | {
     @statusCode statusCode: 404;
   };
-    
+
   @doc("Get all pending members of a group. Will reject the request from access level 'user'.")
   @route("/groups/{id}/pendingMembers")
   @get


### PR DESCRIPTION
## Type of changes
- Feature

## Purpose
- Add request and response model for links
- Add link CUD endpoints to let the group owner or group admin manage the link in their group
- Include the links when get single group by id

## Additional information
Affected endpoints
- `GET /api/groups/{id}`
- `POST /api/groups/{id}/link`
- `PUT /api/groups/{id}/link/{linkId}`
- `DELETE /api/groups/{id}/link/{linkId}`