### PR TITLE
Add list jobs, count jobs by status, and get available partitions APIs

### DIFF
--- a/main.tsp
+++ b/main.tsp
@@ -4,6 +4,7 @@ import "./service/group.tsp";
 import "./service/user.tsp";
 import "./service/auth.tsp";
 import "./service/admin.tsp";
+import "./service/job.tsp";
 
 using Http;
 using Versioning;

--- a/service/job.tsp
+++ b/service/job.tsp
@@ -1,0 +1,53 @@
+import "@typespec/http";
+using Http;
+
+@tag("Job")
+namespace Clustron.Job {
+    model FilterParams {
+        @example("status")
+        @doc("The column to filter by.")
+        @query
+        filterBy?: string;
+
+        @example("running")
+        @doc("The value to filter by.")
+        @query
+        filterValue?: string;
+    }
+
+    model JobResponse {
+        @doc("The ID of the job.")
+        id: numeric;
+
+        @doc("The name of the job.")
+        name: string;
+
+        @doc("The description of the job.")
+        comment: string;
+
+        @doc("The status of the job.")
+        status: string;
+
+        @doc("The computer user who created the job.")
+        user: string;
+
+        @doc("The partition the job belongs to.")
+        partition: string;
+
+        @doc("The resources allocated for the job.")
+        resources: {
+            cpu: numeric;
+            memory: numeric;
+            gpu: numeric;
+        };
+    }
+
+    @route("/jobs")
+    @get
+    op listJobs(...PaginatedParams, ...FilterParams): {
+        @statusCode statusCode: 200;
+        @body response: PaginatedResponse<JobResponse>;
+    } | {
+        @statusCode statusCode: 404;
+    };
+}

--- a/service/job.tsp
+++ b/service/job.tsp
@@ -50,4 +50,30 @@ namespace Clustron.Job {
     } | {
         @statusCode statusCode: 404;
     };
+
+    @route("/jobs/counts")
+    @get
+    op countJobs(
+        @doc("The status of jobs to count. If not provided, counts all statuses.")
+        @query
+        status?:
+            | "RUNNING"
+            | "PENDING"
+            | "COMPLETED"
+            | "FAILED"
+            | "TIMEOUT"
+            | "CANCELLED",
+    ): {
+        @statusCode statusCode: 200;
+        @body response: {
+            running: numeric;
+            pending: numeric;
+            completed: numeric;
+            failed: numeric;
+            timeout: numeric;
+            cancelled: numeric;
+        };
+    } | {
+        @statusCode statusCode: 400;
+    };
 }

--- a/service/job.tsp
+++ b/service/job.tsp
@@ -51,6 +51,7 @@ namespace Clustron.Job {
         @statusCode statusCode: 404;
     };
 
+    @doc("Count jobs by status.")
     @route("/jobs/counts")
     @get
     op countJobs(
@@ -75,5 +76,16 @@ namespace Clustron.Job {
         };
     } | {
         @statusCode statusCode: 400;
+    };
+
+    @doc("Get available partitions.")
+    @route("/jobs/partitions")
+    op getPartitions(): {
+        @statusCode statusCode: 200;
+        @body response: {
+            partitions: string[];
+        };
+    } | {
+        @statusCode statusCode: 404;
     };
 }


### PR DESCRIPTION
## Type of Change
- Feature

## Purpose
- Add list jobs api `GET /api/jobs`
    - Include query parameters for sorting and filtering 
- Add count jobs by status api `GET /api/jobs/count`
    - Include query parameters for counting jobs in a certain status
- Add get available partition api `GET /api/jobs/partitions`