### PR TITLE
Fix bind login method API HTTP method

### DIFF
--- a/service/auth.tsp
+++ b/service/auth.tsp
@@ -62,7 +62,7 @@ namespace Clustron.Auth {
   };
 
   @route("/bind/oauth/{provider}")
-  @post
+  @get
   op bindOAuth(
     @doc("The OAuth2 provider to bind.")
     @path


### PR DESCRIPTION
## Type of Change
- Fix

## Purpose
- The HTTP method of the bind login method API should be GET instead of POST. This problem is fixed in this PR.