### PR TITLE
Define the response type of the unarchive group endpoint

### DIFF
--- a/service/group.tsp
+++ b/service/group.tsp
@@ -263,6 +263,7 @@ namespace Clustron.Groups {
   @post
   op unarchiveGroup(id: string): {
     @statusCode statusCode: 200;
+    @body group: GroupResponse;
   } | {
     @statusCode statusCode: 404;
   };


### PR DESCRIPTION
## Type of changes

- Fix

## Purpose

- Define the response type of the unarchive group endpoint, which is `GroupResponse`.