### PR TITLE
Include fingerprint in get public response and delete public key request

### DIFF
--- a/service/user.tsp
+++ b/service/user.tsp
@@ -39,9 +39,9 @@ namespace Clustron.User {
   }
 
   model PublicKey {
-    @doc("The public key id in UUID format.")
-    @example("123e4567-e89b-12d3-a456-426614174300")
-    id: string;
+    @doc("The public key fingerprint.")
+    @example("GP79vI7mQGl6eKR1b/6qfzzRwkGEUlZ2RA/mX8tVtXc")
+    fingerprint: string;
 
     @doc("The public key title set by the user.")
     @example("workstation-key")
@@ -63,9 +63,9 @@ namespace Clustron.User {
   }
 
   model DeletePublicKeyRequest {
-    @doc("The public key id in UUID format.")
-    @example("123e4567-e89b-12d3-a456-426614174300")
-    id: string;
+    @doc("The public key fingerprint.")
+    @example("GP79vI7mQGl6eKR1b/6qfzzRwkGEUlZ2RA/mX8tVtXc")
+    fingerprint: string;
   }
 
   model OnboardingRequest {


### PR DESCRIPTION
## Type of changes

- Fix

## Purpose

- Include fingerprint in get public key response for identification. Previously use uuid for identification.
- Delete public key by its fingerprint.
- Include fingerprint in delete public key request body because it include slash (cannot be in path parameter).

## Additional information
Affected endpoints
- `GET /publickey`
    response body
    ```
    [
        {
            "fingerprint": "GP79vI7mQGl6eKR1b/6qfzzRwkGEUlZ2RA/mX8tVtXc",
            "title": "workstation-key",
            "publicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3..."
         }
    ]
    ```
- `DELETE /publickey`
    request body
    ```
    {
        "fingerprint": "GP79vI7mQGl6eKR1b/6qfzzRwkGEUlZ2RA/mX8tVtXc"
    }
    ```