### PR TITLE
[CLUST-298] Allow admin to bind clustorn user to linux user

### DIFF
--- a/service/admin.tsp
+++ b/service/admin.tsp
@@ -60,9 +60,6 @@ namespace Clustron.Admin {
   }
 
   model LDAPBindRequest {
-    @doc("The clustron user ID to bind.")
-    userId: uuid;
-
     @doc("The linux username to bind in LDAP. This linux user must exist in LDAP before binding.")
     @example("alice")
     linuxUsername: string;
@@ -149,9 +146,9 @@ namespace Clustron.Admin {
   } | Error.InvalidUuidFormatProblem;
 
   @doc("bind a user to certain linux user in ldap via their linux username. this linux user must exist in ldap before binding")
-  @route("/users/ldapBind")
+  @route("/users/{id}/ldapBind")
   @put
-  op bindUserToLinuxUserInLDAP(@body body: LDAPBindRequest):
+  op bindUserToLinuxUserInLDAP(@path id: uuid, @body body: LDAPBindRequest):
     | {
         @statusCode statusCode: 200;
         @body user: UserResponse;

--- a/service/admin.tsp
+++ b/service/admin.tsp
@@ -27,6 +27,9 @@ namespace Clustron.Admin {
     @example("Alice Chen")
     fullName: string;
 
+    @example("alice")
+    linuxUsername: string;
+
     @example("alice@university.edu")
     email: email;
 
@@ -54,6 +57,15 @@ namespace Clustron.Admin {
     @example(Role.Admin)
     @query
     role?: Role;
+  }
+
+  model LDAPBindRequest {
+    @doc("The clustron user ID to bind.")
+    userId: uuid;
+
+    @doc("The linux username to bind in LDAP. This linux user must exist in LDAP before binding.")
+    @example("alice")
+    linuxUsername: string;
   }
 
   @doc("get all mapping between group wise role and group wise access level")
@@ -135,4 +147,20 @@ namespace Clustron.Admin {
   } | {
     @statusCode statusCode: 403;
   } | Error.InvalidUuidFormatProblem;
+
+  @doc("bind a user to certain linux user in ldap via their linux username. this linux user must exist in ldap before binding")
+  @route("/users/ldapBind")
+  @put
+  op bindUserToLinuxUserInLDAP(@body body: LDAPBindRequest):
+    | {
+        @statusCode statusCode: 200;
+        @body user: UserResponse;
+      }
+    | {
+        @statusCode statusCode: 400;
+      }
+    | {
+        @statusCode statusCode: 403;
+      }
+    | Error.InvalidUuidFormatProblem;
 }


### PR DESCRIPTION
## Type of changes

- Feature

## Purpose

- Add `linuxUsername` field in the list user API.
- Create endpoint `PUT /api/users/{id}/ldapBind` to allow admin to bind a certain Clustron user to another Linux user in LDAP.

<!-- Provide a brief description of the changes made in this pull request. -->

## Additional Information

Affected endpoints:
- `GET /api/users`
- `PUT /api/users/{id}/globalRole`
