### PR TITLE
Add value "UNKNOWN" to AccessLevel enum

### DIFF
--- a/service/group.tsp
+++ b/service/group.tsp
@@ -8,6 +8,9 @@ namespace Clustron.Groups {
     GroupOwner: "GROUP_OWNER",
     GroupAdmin: "GROUP_ADMIN",
     User: "USER",
+
+    @doc("When the user only exists in LDAP but not in the local database, we will assign them with 'unknown' access level.")
+    Unknown: "UNKNOWN",
   }
 
   model Role {


### PR DESCRIPTION
## Type of changes

- Fix

## Purpose

- Add value "UNKNOWN" to AccessLevel enum.
- Maintain the consistency between the API spec and the backend implementation

<!-- Provide a brief description of the changes made in this pull request. -->
