### PR TITLE
Change deploy API document name in CI

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: spec-file
-          path: tsp-output/schema/openapi.1.0.0.yaml
+          path: tsp-output/schema/openapi.yaml
 
       - name: Upload swagger-ui
         uses: actions/upload-artifact@v4
@@ -64,10 +64,10 @@ jobs:
       - name: Generate Redocly and Swagger UI
         run: |
           mkdir -p ./redocly-ui
-          redocly build-docs openapi.1.0.0.yaml --output ./redocly-ui/redocly.html
+          redocly build-docs openapi.yaml --output ./redocly-ui/redocly.html
 
           mkdir -p ./publish
-          cp openapi.1.0.0.yaml ./publish/
+          cp openapi.yaml ./publish/
           cp redocly-ui/redocly.html ./publish/
           cp swagger-ui.html ./publish/index.html
 

--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,4 @@ mock:
 	@docker run --init --rm \
 	    -v $(PWD):/api \
         -p 4010:4010 stoplight/prism:4 \
-        mock -h 0.0.0.0 "/api/tsp-output/schema/openapi.1.0.0.yaml"
+        mock -h 0.0.0.0 "/api/tsp-output/schema/openapi.yaml"

--- a/swagger-ui.html
+++ b/swagger-ui.html
@@ -1,22 +1,28 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="SwaggerUI" />
-  <title>SwaggerUI</title>
-  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css" />
-</head>
-<body>
-<div id="swagger-ui"></div>
-<script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js" crossorigin></script>
-<script>
-  window.onload = () => {
-    window.ui = SwaggerUIBundle({
-      url: 'https://nycu-sdc.github.io/clustron-api/openapi.1.0.0.yaml',
-      dom_id: '#swagger-ui',
-    });
-  };
-</script>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="SwaggerUI" />
+    <title>SwaggerUI</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css"
+    />
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script
+      src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js"
+      crossorigin
+    ></script>
+    <script>
+      window.onload = () => {
+        window.ui = SwaggerUIBundle({
+          url: "https://nycu-sdc.github.io/clustron-api/openapi.yaml",
+          dom_id: "#swagger-ui",
+        });
+      };
+    </script>
+  </body>
 </html>

--- a/tspconfig.yaml
+++ b/tspconfig.yaml
@@ -5,3 +5,4 @@ options:
     emitter-output-dir: "{output-dir}/schema"
     openapi-versions:
       - 3.1.0
+    output-file: "openapi.yaml"


### PR DESCRIPTION
## Type of changes

- CI

## Purpose

- Change deploy API document name in CI to `opanapi.yaml` (without version tag) to prevent issues when updating version.
