### PR TITLE
[CLUST-307] Add endpoints to update group title and description

### DIFF
--- a/service/group.tsp
+++ b/service/group.tsp
@@ -167,13 +167,13 @@ namespace Clustron.Groups {
     links: LinkResponse[];
   }
 
-  model GroupTitleUpdateRequest {
+  model UpdateGroupTitleRequest {
     @doc("The new title of the group.")
     @example("Updated GPU Research Group")
     title: string;
   }
 
-  model GroupDescriptionUpdateRequest {
+  model UpdateGroupDescriptionRequest {
     @doc("The new description of the group.")
     @example("Updated group for GPU research and experiments.")
     description: string;
@@ -295,7 +295,7 @@ namespace Clustron.Groups {
   @doc("Update a group's title.")
   @route("/groups/{id}/title")
   @patch
-  op patchGroupTitle(id: string, @body body: GroupTitleUpdateRequest): {
+  op patchGroupTitle(id: string, @body body: UpdateGroupTitleRequest): {
     @statusCode statusCode: 200;
     @body group: GroupResponse;
   } | {
@@ -307,7 +307,7 @@ namespace Clustron.Groups {
   @patch
   op patchGroupDescription(
     id: string,
-    @body body: GroupDescriptionUpdateRequest,
+    @body body: UpdateGroupDescriptionRequest,
   ): {
     @statusCode statusCode: 200;
     @body group: GroupResponse;

--- a/service/group.tsp
+++ b/service/group.tsp
@@ -167,6 +167,18 @@ namespace Clustron.Groups {
     links: LinkResponse[];
   }
 
+  model GroupTitleUpdateRequest {
+    @doc("The new title of the group.")
+    @example("Updated GPU Research Group")
+    title: string;
+  }
+
+  model GroupDescriptionUpdateRequest {
+    @doc("The new description of the group.")
+    @example("Updated group for GPU research and experiments.")
+    description: string;
+  }
+
   model AddMemberError {
     @example("bob@university.edu")
     member: string;
@@ -276,6 +288,29 @@ namespace Clustron.Groups {
   @delete
   op deleteGroup(id: string): {
     @statusCode statusCode: 204;
+  } | {
+    @statusCode statusCode: 404;
+  };
+
+  @doc("Update a group's title.")
+  @route("/groups/{id}/title")
+  @patch
+  op patchGroupTitle(id: string, @body body: GroupTitleUpdateRequest): {
+    @statusCode statusCode: 200;
+    @body group: GroupResponse;
+  } | {
+    @statusCode statusCode: 404;
+  };
+
+  @doc("Update a group's description.")
+  @route("/groups/{id}/description")
+  @patch
+  op patchGroupDescription(
+    id: string,
+    @body body: GroupDescriptionUpdateRequest,
+  ): {
+    @statusCode statusCode: 200;
+    @body group: GroupResponse;
   } | {
     @statusCode statusCode: 404;
   };


### PR DESCRIPTION
## Type of changes

- Feature

## Purpose

- Add `PATCH /api/groups/{id}/title` for updating the title of the group
- Add `PATCH /api/groups/{id}/description` for updating the description of the group
